### PR TITLE
Use Roboto Mono for times

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet" />
     <title>Tauri + React + Typescript</title>
   </head>
 

--- a/src/components/BusItem.tsx
+++ b/src/components/BusItem.tsx
@@ -11,7 +11,7 @@ interface BusItemProps {
 const BusItem: React.FC<BusItemProps> = ({ time, remainingMinutes, color }) => {
   return (
     <div className="flex justify-center items-center px-4 py-3 border-t border-gray-700">
-      <span className="text-2xl font-bold" style={{ color }}>{time}</span>
+      <span className="text-2xl font-bold font-mono" style={{ color }}>{time}</span>
       <span className="ml-3">
         <RemainingTime minutes={remainingMinutes} format="default" />
       </span>

--- a/src/components/StationCard.tsx
+++ b/src/components/StationCard.tsx
@@ -11,7 +11,7 @@ interface TrainItemProps {
 const TrainItem: React.FC<TrainItemProps> = ({ train, color }) => {
   return (
     <div className="flex justify-between items-center px-4 py-3 border-t border-gray-700">
-      <span className="text-2xl font-bold" style={{ color }}>{train.time}</span>
+      <span className="text-2xl font-bold font-mono" style={{ color }}>{train.time}</span>
       <span className="flex-1 mx-3 truncate text-lg text-gray-200">{train.destination}</span>
       <RemainingTime minutes={train.remainingMinutes} format="compact" />
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,11 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        mono: ["'Roboto Mono'", 'monospace'],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- load Roboto Mono in `index.html`
- update Tailwind config so `font-mono` uses Roboto Mono
- apply `font-mono` to time values for buses and trains

## Testing
- `npm run build` *(fails: Cannot find module 'react')*