### PR TITLE
Set default Japanese font

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet" />
     <title>Tauri + React + Typescript</title>
   </head>
 
-  <body>
+  <body class="font-sans">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ export default {
     extend: {
       fontFamily: {
         mono: ["'Roboto Mono'", 'monospace'],
+        sans: ["'Noto Sans JP'", 'sans-serif'],
       },
 
       colors: {


### PR DESCRIPTION
## Summary
- use Google Fonts for Japanese text
- apply font-sans to the whole body
- set Tailwind's default sans font to Noto Sans JP

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*