### PR TITLE
Add Dockerfile for Tauri X11 runtime

### DIFF
--- a/Dockerfile.tauri-x11
+++ b/Dockerfile.tauri-x11
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+
+# ----- Build Stage -----
+FROM ghcr.io/tauri-apps/builder:latest AS build
+WORKDIR /app
+
+# install bun for frontend build
+RUN npm install -g bun
+
+# install Rust toolchain (provided by builder image) and Tauri CLI
+RUN cargo install tauri-cli --locked
+
+# install dependencies and build frontend
+COPY package.json bun.lockb ./
+RUN bun install --frozen-lockfile
+
+# copy sources
+COPY . .
+
+# build frontend assets
+RUN bun run build
+
+# build tauri binary
+RUN cargo build --release --manifest-path src-tauri/Cargo.toml
+
+# ----- Runtime Stage -----
+FROM ubuntu:22.04 AS runtime
+
+# install libraries required to run tauri and X11 utilities
+RUN apt-get update && apt-get install -y \
+    libwebkit2gtk-4.1-0 \
+    libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxrandr2 libxi6 \
+    libgtk-3-0 libayatana-appindicator3-1 librsvg2-2 \
+    xauth x11-xserver-utils xinput xrandr && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# copy the built binary
+COPY --from=build /app/src-tauri/target/release/tauri-app ./tauri-app
+
+# add entry script
+COPY x11-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/x11-entrypoint.sh
+++ b/x11-entrypoint.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+echo "--- List Input Devices ---"
+xinput list
+echo "----- End of List --------"
+
+function reverse_window_coordinates () {
+  local INPUT=$1
+
+  IFS=', ' read -a coords <<< $INPUT
+  if [ ${#coords[@]} -eq 2 ]; then
+    echo "${coords[1]},${coords[0]}"
+  else
+    echo "Screen coordinates not set correctly, so cannot reverse them."
+  fi 
+}
+
+function rotate_touch () {
+  echo "Rotating Input ($1): $2"
+  local TRANSFORM='Coordinate Transformation Matrix'
+
+  case "$2" in
+    normal)   xinput set-prop "$1" "$TRANSFORM" 1 0 0 0 1 0 0 0 1;;
+    inverted) xinput set-prop "$1" "$TRANSFORM" -1 0 1 0 -1 1 0 0 1;;
+    left)     xinput set-prop "$1" "$TRANSFORM" 0 -1 1 1 0 0 0 0 1;;
+    right)    xinput set-prop "$1" "$TRANSFORM" 0 1 0 -1 0 1 0 0 1;;
+  esac
+}
+
+if [[ -z "$WINDOW_SIZE" ]]; then
+  # detect the window size from the framebuffer file
+  echo "Detecting window size from framebuffer"
+  export WINDOW_SIZE=$( cat /sys/class/graphics/fb0/virtual_size )
+  echo "Window size detected as $WINDOW_SIZE"
+else
+  echo "Window size set by environment variable to $WINDOW_SIZE"
+fi
+
+# rotate screen if env variable is set [normal, inverted, left or right]
+if [[ ! -z "$ROTATE_DISPLAY" ]]; then
+  ROTATE_DELAY="${ROTATE_DELAY:-3}"
+
+  sleep "$ROTATE_DELAY" && xrandr -o $ROTATE_DISPLAY
+
+  #If the display is rotated to left or right, we need to reverse the size and position coords
+  if [[ "$ROTATE_DISPLAY" == "left" ]] || [[ "$ROTATE_DISPLAY" == "right" ]]; then
+    
+    echo "Display rotated to portait. Reversing screen coordinates"
+    
+    #window size
+    REVERSED_SIZE="$(reverse_window_coordinates $WINDOW_SIZE)"
+    WINDOW_SIZE=$REVERSED_SIZE
+    echo "Reversed window size: $WINDOW_SIZE"
+    
+    #window position, if set
+    if [[ "$WINDOW_POSITION" -ne "0,0" ]]
+    then
+      REVERSED_POSITION="$(reverse_window_coordinates $WINDOW_POSITION)"
+      export WINDOW_POSITION=$REVERSED_POSITION
+      echo "Reversed window position: $WINDOW_POSITION"
+    fi
+  fi
+
+  echo "Rotate Touch Inputs"
+  if [[ ! -z "$TOUCHSCREEN" ]]; then
+    rotate_touch "$TOUCHSCREEN" "$ROTATE_DISPLAY"
+  else
+    devices=$( xinput --list | fgrep Touch | sed -E 's/^.*id=([0-9]+).*$/\1/' )
+    for device in ${devices} ;do
+        rotate_touch $device $ROTATE_DISPLAY
+    done
+  fi
+fi
+
+# disable screen blanking
+xset s off -dpms
+
+exec /app/tauri-app


### PR DESCRIPTION
## Summary
- create Dockerfile for running Tauri app with X11
- provide entrypoint script to handle display rotation and run the app

## Testing
- `bun run build` *(fails: cannot find dependencies)*

<!-- Copilotのレビューは日本語で行ってください -->