### PR TITLE
Add Dockerfile for Tauri X11 runtime

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,70 @@
+# syntax=docker/dockerfile:1
+
+# ビルド時の引数
+ARG API_BASE_URL=http://localhost:3000
+ARG SHOW_FOOTER=true
+ARG DEBUG_DATETIME=
+
+# ---- Build stage ----
+FROM oven/bun:1 AS build
+WORKDIR /app
+
+# ビルド引数を受け取る
+ARG API_BASE_URL
+ARG SHOW_FOOTER
+ARG DEBUG_DATETIME
+
+# ビルド環境変数を設定
+ENV VITE_API_BASE_URL=${API_BASE_URL}
+ENV VITE_SHOW_FOOTER=${SHOW_FOOTER}
+ENV VITE_DEBUG_DATETIME=${DEBUG_DATETIME}
+
+# install dependencies
+COPY package.json bun.lockb ./
+RUN bun install --frozen-lockfile
+
+# copy source and build
+COPY . .
+RUN bun run build
+
+# ---- Runtime stage ----
+FROM nginx:alpine
+
+# ビルド引数を受け取る
+ARG API_BASE_URL
+ARG SHOW_FOOTER
+ARG DEBUG_DATETIME
+
+# 実行時のデフォルト環境変数を設定
+ENV API_BASE_URL=${API_BASE_URL}
+ENV SHOW_FOOTER=${SHOW_FOOTER}
+ENV DEBUG_DATETIME=${DEBUG_DATETIME}
+
+# install envsubst
+RUN apk add --no-cache gettext
+
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# generate runtime config template and entry script
+RUN echo 'window.RUNTIME_CONFIG = {' > /usr/share/nginx/html/config.js.template && \
+  echo '  API_BASE_URL: "${API_BASE_URL}",' >> /usr/share/nginx/html/config.js.template && \
+  echo '  SHOW_FOOTER: "${SHOW_FOOTER}",' >> /usr/share/nginx/html/config.js.template && \
+  echo '  DEBUG_DATETIME: "${DEBUG_DATETIME}"' >> /usr/share/nginx/html/config.js.template && \
+  echo '};' >> /usr/share/nginx/html/config.js.template
+
+RUN sed -i '/<\/head>/i \    <script src="/config.js"></script>' /usr/share/nginx/html/index.html
+
+# Create a more robust entrypoint script
+RUN echo '#!/bin/sh' > /docker-entrypoint.sh && \
+  echo 'set -e' >> /docker-entrypoint.sh && \
+  echo 'echo "Generating config.js with API_BASE_URL=${API_BASE_URL}"' >> /docker-entrypoint.sh && \
+  echo 'envsubst < /usr/share/nginx/html/config.js.template > /usr/share/nginx/html/config.js' >> /docker-entrypoint.sh && \
+  echo 'cat /usr/share/nginx/html/config.js' >> /docker-entrypoint.sh && \
+  echo 'echo "Starting nginx..."' >> /docker-entrypoint.sh && \
+  echo 'exec nginx -g "daemon off;"' >> /docker-entrypoint.sh
+
+RUN chmod +x /docker-entrypoint.sh
+
+EXPOSE 80
+
+CMD ["/docker-entrypoint.sh"]

--- a/x11-entrypoint.sh
+++ b/x11-entrypoint.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+echo "--- List Input Devices ---"
+xinput list
+echo "----- End of List --------"
+
+function reverse_window_coordinates () {
+  local INPUT=$1
+
+  IFS=', ' read -a coords <<< $INPUT
+  if [ ${#coords[@]} -eq 2 ]; then
+    echo "${coords[1]},${coords[0]}"
+  else
+    echo "Screen coordinates not set correctly, so cannot reverse them."
+  fi 
+}
+
+function rotate_touch () {
+  echo "Rotating Input ($1): $2"
+  local TRANSFORM='Coordinate Transformation Matrix'
+
+  case "$2" in
+    normal)   xinput set-prop "$1" "$TRANSFORM" 1 0 0 0 1 0 0 0 1;;
+    inverted) xinput set-prop "$1" "$TRANSFORM" -1 0 1 0 -1 1 0 0 1;;
+    left)     xinput set-prop "$1" "$TRANSFORM" 0 -1 1 1 0 0 0 0 1;;
+    right)    xinput set-prop "$1" "$TRANSFORM" 0 1 0 -1 0 1 0 0 1;;
+  esac
+}
+
+if [[ -z "$WINDOW_SIZE" ]]; then
+  # detect the window size from the framebuffer file
+  echo "Detecting window size from framebuffer"
+  export WINDOW_SIZE=$( cat /sys/class/graphics/fb0/virtual_size )
+  echo "Window size detected as $WINDOW_SIZE"
+else
+  echo "Window size set by environment variable to $WINDOW_SIZE"
+fi
+
+# rotate screen if env variable is set [normal, inverted, left or right]
+if [[ ! -z "$ROTATE_DISPLAY" ]]; then
+  ROTATE_DELAY="${ROTATE_DELAY:-3}"
+
+  sleep "$ROTATE_DELAY" && xrandr -o $ROTATE_DISPLAY
+
+  #If the display is rotated to left or right, we need to reverse the size and position coords
+  if [[ "$ROTATE_DISPLAY" == "left" ]] || [[ "$ROTATE_DISPLAY" == "right" ]]; then
+    
+    echo "Display rotated to portait. Reversing screen coordinates"
+    
+    #window size
+    REVERSED_SIZE="$(reverse_window_coordinates $WINDOW_SIZE)"
+    WINDOW_SIZE=$REVERSED_SIZE
+    echo "Reversed window size: $WINDOW_SIZE"
+    
+    #window position, if set
+    if [[ "$WINDOW_POSITION" -ne "0,0" ]]
+    then
+      REVERSED_POSITION="$(reverse_window_coordinates $WINDOW_POSITION)"
+      export WINDOW_POSITION=$REVERSED_POSITION
+      echo "Reversed window position: $WINDOW_POSITION"
+    fi
+  fi
+
+  echo "Rotate Touch Inputs"
+  if [[ ! -z "$TOUCHSCREEN" ]]; then
+    rotate_touch "$TOUCHSCREEN" "$ROTATE_DISPLAY"
+  else
+    devices=$( xinput --list | fgrep Touch | sed -E 's/^.*id=([0-9]+).*$/\1/' )
+    for device in ${devices} ;do
+        rotate_touch $device $ROTATE_DISPLAY
+    done
+  fi
+fi
+
+# disable screen blanking
+xset s off -dpms
+
+exec /app/tauri-app

--- a/x11-entrypoint.sh
+++ b/x11-entrypoint.sh
@@ -7,7 +7,7 @@ echo "----- End of List --------"
 function reverse_window_coordinates () {
   local INPUT=$1
 
-  IFS=', ' read -a coords <<< $INPUT
+  IFS=', ' read -a coords <<< "$INPUT"
   if [ ${#coords[@]} -eq 2 ]; then
     echo "${coords[1]},${coords[0]}"
   else

--- a/x11-entrypoint.sh
+++ b/x11-entrypoint.sh
@@ -53,7 +53,7 @@ if [[ ! -z "$ROTATE_DISPLAY" ]]; then
     echo "Reversed window size: $WINDOW_SIZE"
     
     #window position, if set
-    if [[ "$WINDOW_POSITION" -ne "0,0" ]]
+    if [[ "$WINDOW_POSITION" != "0,0" ]]
     then
       REVERSED_POSITION="$(reverse_window_coordinates $WINDOW_POSITION)"
       export WINDOW_POSITION=$REVERSED_POSITION


### PR DESCRIPTION
## Summary
- replace the default Dockerfile with one that builds and runs the Tauri app under X11
- keep the previous web Dockerfile as `Dockerfile.web`

## Testing
- `bun run build` *(fails: missing React and other dependencies)*

<!-- Copilotのレビューは日本語で行ってください -->