### PR TITLE
Fix Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1
 
 # ----- Build Stage -----
-FROM ghcr.io/tauri-apps/builder:latest AS build
+# Use Docker Hub mirror of the Tauri builder image to avoid authentication
+# issues when pulling from GitHub Container Registry on remote builders.
+FROM tauri-apps/builder:latest AS build
 WORKDIR /app
 
 # install bun for frontend build


### PR DESCRIPTION
## Summary
- change the Tauri builder image to the Docker Hub mirror

## Testing
- `bun run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*