### PR TITLE
Fix start script to prevent screen sleep

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,8 @@
 cat > ~/.xinitrc << 'EOF'
 export GDK_SCALE=$WINDOW_SCALE
+xset s noblank
+xset s off
+xset -dpms
 openbox &
 "$(pwd)/tauri-app" &
 sleep 2
@@ -8,10 +11,6 @@ wmctrl -i -r $WIN_ID -b add,fullscreen
 unclutter -idle 0 -root &
 wait
 EOF
-
-xset s noblank
-xset s off
-xset -dpms
 
 ROT=${ROTATE_DISPLAY:-right}
 case "$ROT" in


### PR DESCRIPTION
## Summary
- disable blanking and DPMS inside the X session

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `cargo test --manifest-path src-tauri/Cargo.toml --quiet` *(fails to fetch dependencies: network not available)*

------
https://chatgpt.com/codex/tasks/task_e_685bd3c91fa8832f8a7f5a603fd44caa